### PR TITLE
add .xmatch to match statement

### DIFF
--- a/parser/src/tokenizer.rs
+++ b/parser/src/tokenizer.rs
@@ -159,7 +159,7 @@ impl<'a> Tokenizer<'a> {
                     ".loword" | ".hiword" | ".bankbyte" | ".lobyte" | ".hibyte" => {
                         self.make_token(TokenType::WordOp)
                     }
-                    ".match" => self.make_token(TokenType::Match),
+                    ".match" | ".xmatch" => self.make_token(TokenType::Match),
                     ".def" | ".defined" => self.make_token(TokenType::Def),
                     ".left" | ".mid" | ".right" => self.make_token(TokenType::Extract),
                     _ => self.make_token(TokenType::Macro),


### PR DESCRIPTION
Lol I didn't know tech already had `.match` parsing logic. This ticket just adds `.xmatch` to the party

---

# What's changing
Adding support for [`.match`](https://cc65.github.io/doc/ca65.html#ss10.16) and [`.xmatch`](https://cc65.github.io/doc/ca65.html#ss10.28) 

# Motivation for change
Currently the parser yells at you for correct match syntax
This is a fairly commonly used directive in ca65 macros

# Background/Notes
[cc65 `DoMatch` parser function](https://github.com/cc65/cc65/blob/master/src/ca65/expr.c#L583)

both handle parentheses AND no parentheses